### PR TITLE
heartbeat mechanism between umap_stack and fuzzer

### DIFF
--- a/MAXUSBApp.py
+++ b/MAXUSBApp.py
@@ -260,6 +260,11 @@ class MAXUSBApp(FacedancerApp):
         if os.path.isfile(trigger):
             os.remove(trigger)
 
+    def send_heartbeat(self):
+        heartbeat_file = '/tmp/umap_kitty/heartbeat'
+        with open(heartbeat_file, 'a'):
+            os.utime(heartbeat_file, None)
+
     def service_irqs(self):
         count = 0
         tmp_irq = 0
@@ -270,6 +275,7 @@ class MAXUSBApp(FacedancerApp):
             if irq == tmp_irq:
                 count += 1
             else:
+                self.send_heartbeat()
                 count = 0
 
             if count == 10000 and self.mode == 2:  # This needs to be configurable

--- a/fuzzing/controller.py
+++ b/fuzzing/controller.py
@@ -17,6 +17,7 @@ class UmapController(ClientController):
         self.trigger_dir = '/tmp/umap_kitty'
         self.connect_file = 'trigger_reconnect'
         self.disconnect_file = 'trigger_disconnect'
+        self.heartbeat_file = 'heartbeat'
         self.pre_disconnect_delay = pre_disconnect_delay
         self.post_disconnect_delay = post_disconnect_delay
 
@@ -31,6 +32,7 @@ class UmapController(ClientController):
                 os.mkdir(self.trigger_dir)
         self.del_file(self.connect_file)
         self.del_file(self.disconnect_file)
+        self.del_file(self.heartbeat_file)
 
     def setup(self):
         super(UmapController, self).setup()
@@ -58,6 +60,17 @@ class UmapController(ClientController):
             count += 1
             if count % 1000 == 0:
                 self.logger.warning('still waiting for umap_stack to remove the file %s' % path)
+
+    def get_last_heartbeat(self):
+        '''
+        Return the time of the latest heartbeat received from the victim stack
+        (via umap_stack).
+        If no responses have ever been received from the victim, returns 0.
+        '''
+        heartbeat_file = os.path.join(self.trigger_dir, self.heartbeat_file)
+        if not os.path.exists(heartbeat_file):
+            return 0
+        return os.path.getmtime(heartbeat_file)
 
     def pre_test(self, test_number):
         self.trigger_disconnect()


### PR DESCRIPTION
The heartbeat_file's mtime will be updated every time a request from the
victim's host USB stack is received. This allows the fuzzer to monitor the
status of the victim's host USB stack (for example, to identify that the
victim's stack is unresponsive).

Currently going through the filesystem, like the triggering mechanism; however,
depending on the platform, the time-resolution that the mtimes provide may be
limited, so long-term, a different mechanism should probably be used...