### PR TITLE
heartbeat: only send a heartbeat if the directory exists

### DIFF
--- a/MAXUSBApp.py
+++ b/MAXUSBApp.py
@@ -262,8 +262,9 @@ class MAXUSBApp(FacedancerApp):
 
     def send_heartbeat(self):
         heartbeat_file = '/tmp/umap_kitty/heartbeat'
-        with open(heartbeat_file, 'a'):
-            os.utime(heartbeat_file, None)
+        if os.path.isdir(os.path.dirname(heartbeat_file)):
+            with open(heartbeat_file, 'a'):
+                os.utime(heartbeat_file, None)
 
     def service_irqs(self):
         count = 0


### PR DESCRIPTION
The directory in which the file indicating a heartbeat resides is created by
the controller; however, when running with 'nofuzz', there is no controller,
and the directory may not even exist. In such a case, the stack crashes as soon
as it attmpts to send a heartbeat.

The fix here is simply that if the directory doesn't exist, then we just don't
send a heartbeat. This should not be a problem, because if the directory
doesn't exist, then presumably there is nobody listening, anyway...

This is just a hack on a hack; ultimately, the communication should not really
be taking place via the filesystem; but that's for umap2...